### PR TITLE
Add update logic to latency plot and latency metrics

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,12 +11,14 @@ import Brick
 import qualified Brick.Main as M
 import Brick.Widgets.Border
 import Brick.Widgets.Border.Style
-import Chart (Options (..), getPlotLines)
-import Control.Concurrent (newChan)
+import Chart (AppState (..), Options (..), getPlotLines, plotApp)
+import Control.Concurrent (Chan, forkIO, newChan, readChan, threadDelay)
 import Control.Concurrent.Async
 import Control.Monad
 import Data.Text (unpack)
 import Data.Time (NominalDiffTime)
+import qualified Graphics.Vty as V
+import Graphics.Vty.CrossPlatform
 import Options.Applicative
 import qualified Pacer
 import ResultLogger (runLogger)
@@ -26,30 +28,26 @@ import qualified Widgets as W
 import Data.Monoid
 #endif
 
+import Brick.BChan (BChan, newBChan, writeBChan)
+import qualified GHC.Conc.Sync
 import ProgressBar
 import SampleData
-import Widgets (BytesMetrics)
 
 main :: IO ()
 main = do
   cmdFlags <- execParser (info (helper <*> Args.flags) fullDesc)
-  when (plotDemo cmdFlags) $ do
-    let params =
-          W.MkParams
-            { W.target = target cmdFlags,
-              W.rate = rate cmdFlags,
-              W.duration = duration cmdFlags,
-              W.method = method cmdFlags
-            }
-    simpleMain $ ui params myLatencies myBytes myStatusCodes myErrors myOtherStats
+  -- TODO: plotting is still sequential, uses only dummy data
+  when (plotDemo cmdFlags) $ initializeAndRunPlot cmdFlags
 
   when (progressBar cmdFlags) $ do
-    void $ M.defaultMain theApp initialState
+    void $ M.defaultMain theApp initialPBState
+
   let targetter = buildTargetter cmdFlags
   let pacer = buildPacer cmdFlags
   attackChannel <- newChan
   attackerThread <- async $ runAttacker attackChannel targetter pacer
   fetcherThread <- async $ runLogger attackChannel
+  -- graphThread <- async $ updatePlot attackChannel
   wait attackerThread
   wait fetcherThread
 
@@ -69,26 +67,49 @@ buildPacer cmdFlags =
       Pacer.duration = fromIntegral (Args.duration cmdFlags)
     }
 
-plotWidget :: Widget n
-plotWidget =
-  joinBorders $
-    withBorderStyle unicode $
-      borderWithLabel (Brick.str "Plot") $
-        Brick.str (unlines $ getPlotLines myoptions mySeries)
+-- Implement the logic to read from the channel and update the graph
+-- Currently, this uses dummy data, can be extended to use data from the attacker
+initializeAndRunPlot :: Flags -> IO ()
+initializeAndRunPlot cmdFlags = do
+  let params =
+        W.MkParams
+          { W.target = target cmdFlags,
+            W.rate = rate cmdFlags,
+            W.duration = duration cmdFlags,
+            W.method = method cmdFlags
+          }
+      -- initial state with dummy data.
+      -- TODO: latencies should be initialized as empty
+      initialState =
+        AppState
+          { _params = params,
+            _plotOptions = myoptions,
+            _latencies = myLatencies,
+            _bytesMetrics = myBytes,
+            _statusCodes = myStatusCodes,
+            _reqErrors = myErrors,
+            _otherstats = myOtherStats,
+            _numDone = 0,
+            _hitCount = 0
+          }
+  chan <- newBChan 10
+  -- updates latencies in a new thread
+  _ <- sendLatencies myLatencies chan
+  -- TODO: this can be run in it's own thread as well.
+  void $ M.customMainWithDefaultVty (Just chan) plotApp initialState
 
--- The UI widget that includes the ASCII chart
-ui :: W.Params -> [NominalDiffTime] -> W.BytesWidget -> W.StatusCodes -> W.Errors -> W.OtherStats -> Widget ()
-ui params latencies bytes statuscodes errors otherstats =
-  vBox
-    [ plotWidget,
-      hBox
-        [ W.drawParams params,
-          W.drawLatencyStats latencies,
-          W.drawBytes bytes,
-          vBox
-            [ W.drawStatusCodes statuscodes,
-              W.drawErrors errors
-            ],
-          W.drawOtherStats otherstats
-        ]
-    ]
+-- TODO: Currently, this only updates the latencies. Shoudl also allow updates for OtherStats, etc
+sendLatencies :: [NominalDiffTime] -> BChan [NominalDiffTime] -> IO GHC.Conc.Sync.ThreadId
+sendLatencies initLatencies chan = forkIO $ go initLatencies
+  where
+    go latencies = do
+      -- Generate or fetch new latencies
+      value <- generateRandomDouble
+      let newLatencies = latencies ++ [realToFrac value]
+
+      -- Write the new latencies to the channel
+      writeBChan chan newLatencies
+
+      -- Wait for some time before sending the next update
+      threadDelay 1000000
+      go newLatencies

--- a/package.yaml
+++ b/package.yaml
@@ -38,6 +38,8 @@ dependencies:
 - microlens-mtl
 - microlens-th
 - aeson
+- vty-crossplatform
+- random
 
 ghc-options:
 - -Wall

--- a/roebling.cabal
+++ b/roebling.cabal
@@ -59,11 +59,13 @@ library
     , microlens-th
     , optparse-applicative
     , parallel
+    , random
     , stm
     , text
     , time
     , timeit
     , vty
+    , vty-crossplatform
   default-language: Haskell2010
 
 executable roebling-exe
@@ -91,12 +93,14 @@ executable roebling-exe
     , microlens-th
     , optparse-applicative
     , parallel
+    , random
     , roebling
     , stm
     , text
     , time
     , timeit
     , vty
+    , vty-crossplatform
   default-language: Haskell2010
 
 test-suite roebling-test
@@ -125,10 +129,12 @@ test-suite roebling-test
     , microlens-th
     , optparse-applicative
     , parallel
+    , random
     , roebling
     , stm
     , text
     , time
     , timeit
     , vty
+    , vty-crossplatform
   default-language: Haskell2010

--- a/src/Chart.hs
+++ b/src/Chart.hs
@@ -1,40 +1,53 @@
 --- Reference: https://github.com/madnight/asciichart
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE Safe #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{-# HLINT ignore "Use newtype instead of data" #-}
+{-# LANGUAGE LambdaCase #-}
+-- needed for makelenses
+{-# LANGUAGE TemplateHaskell #-}
 
 module Chart
   ( -- * Plot
-    plot,
     plotWith,
     plotWith',
     Options (..),
-    options,
     getPlotLines,
     height,
+    AppState (..),
+    plotApp,
+    ui,
   )
 where
 
+import Brick.AttrMap
+import qualified Brick.Main as M
+import qualified Brick.Types as T
+import Brick.Widgets.Border (borderWithLabel)
+import Brick.Widgets.Border.Style (unicode)
+import Brick.Widgets.Center (hCenter)
+import Brick.Widgets.Core
+import Control.Concurrent.STM (stateTVar)
 import Control.Monad (forM_)
 import Control.Monad.ST (ST, runST)
 import Data.Array.ST.Safe (STArray, getElems, newArray, writeArray)
 import Data.Bool (bool)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd, unfoldr)
+import Data.Time (NominalDiffTime)
+import qualified Graphics.Vty as V
+import Lens.Micro.Mtl
+import Lens.Micro.TH (makeLenses)
 import Text.Printf (printf)
+import Widgets (BytesWidget)
+import qualified Widgets as W
 
 data Options = MkOptions
   { -- | Allows to set the height of the chart.
     height :: Int
   }
 
--- | Provides default options: @Options { 'height' = 14 }@.
-options :: Options
-options =
-  MkOptions {height = 14}
+-- -- | Provides default options: @Options { 'height' = 14 }@.
+-- options :: Options
+-- options =
+--   MkOptions {height = 14}
 
 newArray2D ::
   Integer ->
@@ -45,14 +58,14 @@ newArray2D dimX dimY = newArray ((0, 0), (dimX, dimY)) " "
 splitEvery :: Int -> [a] -> [[a]]
 splitEvery n = takeWhile (not . null) . unfoldr (Just . splitAt n)
 
-pad :: (Integral a) => [a] -> Int
+pad :: (Real a) => [a] -> Int
 pad series =
-  let floats = fromIntegral <$> series
+  let floats = realToFrac <$> series
       toStr :: [Float] -> [String]
       toStr = fmap (printf "%0.2f")
    in maximum $ length <$> toStr floats
 
-plotWith' :: Options -> [Integer] -> [String]
+plotWith' :: Options -> [Double] -> [String]
 plotWith' opts series =
   -- variables and functions
   let min' = minimum series
@@ -62,9 +75,9 @@ plotWith' opts series =
       ratio =
         if range == 0
           then 1
-          else fromIntegral (height opts) / fromIntegral range :: Float
-      min2 = fromIntegral min' * ratio
-      max2 = fromIntegral max' * ratio
+          else fromIntegral (height opts) / realToFrac range :: Float
+      min2 = realToFrac min' * ratio
+      max2 = realToFrac max' * ratio
       rows = round $ abs $ max2 - min2
       width = toInteger $ length series + 3
    in runST $ do
@@ -78,22 +91,22 @@ plotWith' opts series =
                 if rows == 0
                   then y
                   else
-                    fromInteger max'
+                    realToFrac max'
                       - (y - min2)
-                        * fromInteger range
+                        * realToFrac range
                         / fromIntegral rows
           result [round $ y - min2] [max 0 $ offset - 5] $
             printf ("%" ++ show (pad series) ++ ".2f") label
           result [round $ y - min2] [offset - 1] . bool "┤" "┼" $ y == 0
 
         -- initial value
-        let first = fromInteger (head series) * ratio - min2
+        let first = realToFrac (head series) * ratio - min2
         result [round $ fromInteger rows - first] [offset - 1] "┼"
 
         -- plot the line
         forM_ [0 .. length series - 2] $ \x -> do
           let offset' = toInteger x + offset
-          let y' i = round (fromInteger (series !! i) * ratio) - round min2
+          let y' i = round (realToFrac (series !! i) * ratio) - round min2
           let (y0, y1) = (y' x, y' $ x + 1)
           if y0 == y1
             then result [rows - y0] [offset'] "─"
@@ -106,14 +119,14 @@ plotWith' opts series =
 
         getElems arr
 
--- | Takes a List of Integers and prints out a
---   corresponding chart with a default terminal height of 14 blocks.
-plot :: [Integer] -> IO ()
-plot x = if length x < 1 then return () else plotWith options x
+-- -- | Takes a List of Integers and prints out a
+-- --   corresponding chart with a default terminal height of 14 blocks.
+-- plot :: [Double] -> IO ()
+-- plot x = if length x < 1 then return () else plotWith options x
 
 -- | Same as plot but it's possible to define custom options.
 --   Example: @'plotWith' options { 'height' = 20 }@
-plotWith :: Options -> [Integer] -> IO ()
+plotWith :: Options -> [Double] -> IO ()
 plotWith options' series =
   forM_ result $
     putStrLn . dropWhileEnd isSpace . concat
@@ -121,7 +134,84 @@ plotWith options' series =
     result = splitEvery (length series + 4) $ plotWith' options' series
 
 -- TODO: what's the magic 4 number used by asciichart?
-getPlotLines :: Options -> [Integer] -> [String]
+getPlotLines :: Options -> [Double] -> [String]
 getPlotLines options' series = map (dropWhileEnd isSpace . concat) result
   where
     result = splitEvery (length series + 4) $ plotWith' options' series
+
+type Name = ()
+
+data AppState = AppState
+  { _latencies :: [NominalDiffTime],
+    _numDone :: Int, -- current progress
+    _hitCount :: Int, -- total number needed
+    _bytesMetrics :: BytesWidget,
+    _plotOptions :: Options,
+    _params :: W.Params,
+    _statusCodes :: W.StatusCodes,
+    _reqErrors :: W.Errors,
+    _otherstats :: W.OtherStats
+    -- Include other fields as necessary
+  }
+
+makeLenses ''AppState -- provides a convenient way to access state vars while handling events
+
+-- | The main Brick application
+plotApp :: M.App AppState [NominalDiffTime] Name
+plotApp =
+  M.App
+    { M.appDraw = drawUI,
+      M.appChooseCursor = M.showFirstCursor,
+      M.appHandleEvent = handleEvent,
+      M.appStartEvent = return (),
+      M.appAttrMap = const theMap
+    }
+
+-- TODO: Dummy attribute map for now. Can add colors etc here
+theMap :: Brick.AttrMap.AttrMap
+theMap = Brick.AttrMap.attrMap V.defAttr []
+
+-- | The plotting Widget
+plotWidget :: Options -> [Double] -> T.Widget n
+plotWidget myoptions mylatencies =
+  joinBorders $
+    withBorderStyle unicode $
+      borderWithLabel (str "Latencies") $
+        str (unlines $ getPlotLines myoptions mylatencies)
+
+-- | Final combined UI with all the Widgets
+drawUI :: AppState -> [T.Widget ()]
+drawUI state = [go]
+  where
+    go = ui myparams myoptions mylatencies mybytes mystatuscodes myerrors myotherstats
+    myparams = _params state
+    myoptions = _plotOptions state
+    mylatencies = _latencies state
+    mybytes = _bytesMetrics state
+    mystatuscodes = _statusCodes state
+    myerrors = _reqErrors state
+    myotherstats = _otherstats state
+
+-- The UI widget that includes the ASCII chart
+ui :: W.Params -> Options -> [NominalDiffTime] -> W.BytesWidget -> W.StatusCodes -> W.Errors -> W.OtherStats -> T.Widget ()
+ui myparams myoptions mylatencies bytes statuscodes errors myotherstats =
+  vBox
+    [ plotWidget myoptions (map realToFrac mylatencies :: [Double]),
+      hBox
+        [ W.drawParams myparams,
+          W.drawLatencyStats mylatencies,
+          W.drawBytes bytes,
+          vBox
+            [ W.drawStatusCodes statuscodes,
+              W.drawErrors errors
+            ],
+          W.drawOtherStats myotherstats
+        ]
+    ]
+
+-- TODO: Currently, an event is either a keyboard entry or a list of latencies. This should include other data like OtherStats, etc.
+handleEvent :: T.BrickEvent Name [NominalDiffTime] -> T.EventM Name AppState ()
+handleEvent e = case e of
+  (T.AppEvent newLatencies) -> latencies %= const newLatencies
+  (T.VtyEvent (V.EvKey (V.KChar 'q') [])) -> M.halt
+  _ -> return ()

--- a/src/ProgressBar.hs
+++ b/src/ProgressBar.hs
@@ -62,8 +62,8 @@ appEvent (T.VtyEvent e) =
         _ -> return ()
 appEvent _ = return ()
 
-initialState :: MyAppState ()
-initialState = MyAppState 0.0
+initialPBState :: MyAppState ()
+initialPBState = MyAppState 0.0
 
 theBaseAttr :: A.AttrName
 theBaseAttr = A.attrName "theBase"

--- a/src/SampleData.hs
+++ b/src/SampleData.hs
@@ -4,6 +4,7 @@ import Chart
 import qualified Data.Map as M
 import Data.Set (fromList)
 import Data.Time
+import System.Random
 import Widgets
 
 dummyDay :: Day
@@ -20,7 +21,7 @@ mySeries :: [Integer]
 mySeries = [1 .. 20]
 
 myLatencies :: [NominalDiffTime]
-myLatencies = map fromRational [0.8, 0.7, 0.98, 0.55, 0.66]
+myLatencies = map fromRational [0.8, 0.7, 0.98, 0.55, 2]
 
 myoptions :: Options
 myoptions = MkOptions {height = 14}
@@ -49,3 +50,9 @@ myOtherStats =
       latest = dummyUTCTime,
       end = dummyUTCTime
     }
+
+generateRandomDouble :: IO Double
+generateRandomDouble = do
+  g <- newStdGen -- Create a new random number generator
+  let (value, _) = randomR (0.0, 1.0) g -- Generate a random Double between 0.0 and 1.0
+  return value

--- a/src/Widgets.hs
+++ b/src/Widgets.hs
@@ -2,10 +2,12 @@
 
 module Widgets where
 
+import Attacker (AttackResult (..), AttackResultMessage (..))
 import Brick
 import Brick.Widgets.Border
 import Brick.Widgets.Border.Style (unicode)
 import qualified Brick.Widgets.Border.Style as BS
+import Control.Concurrent (Chan, readChan)
 import Data.List (sort)
 import qualified Data.Map as M
 import Data.Set (Set, toList)
@@ -22,6 +24,7 @@ data Params = MkParams
     method :: Text -- HTTP request type (GET, etc)
   }
 
+-- TODO: Add centering to make sure latency plot occupies the full width
 drawLatencyStats :: [NominalDiffTime] -> Widget ()
 drawLatencyStats latencies =
   withBorderStyle unicode $
@@ -184,3 +187,22 @@ drawErrors e =
   withBorderStyle unicode $
     borderWithLabel (str "Errors") $
       Brick.str (show e)
+
+-- updatePlot :: Chan AttackResultMessage -> IO ()
+-- updatePlot channel = do
+--   loop Nothing
+--   where
+--     loop msg = do
+--       res <- readChan channel
+--       case res of
+--         StopMessage hitCount -> do
+--           -- print $ "Logger ==> Will stop at Hit: " ++ show hitCount
+--           loop $ Just (hitCount - 1)
+--         ResultMessage (AttackResult hitCount code latency) -> do
+--           if msg /= Just (hitCount + 1)
+--             then do
+--               -- print $ "Logger ==> Hit: " ++ show hitCount ++ ", Code: " ++ show code ++ ", Latency: " ++ show latency
+
+--               loop msg
+--             else do
+--               return ()


### PR DESCRIPTION
# What does this PR do?

Uses `brick`'s event handling to add update functionality for the latency plot and metrics. I'm using a `BChan` channel where I dump a new list of latencies at a fixed, dummy frequency. This can be extended to only use a new latency value and also updated state for other metrics (throughput, etc). 

Brick's Widget resizing isn't great, so the plot starts off very small. Not too sure how to fix this.

Here's a demo for how the UI gets updated:

https://github.com/r2mishra/roebling/assets/39546518/aabe6c16-6dcc-4fb1-8a54-74f38b1f19c9

